### PR TITLE
Add an API Libraries section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ API still under development
 * Moving todos and todolists: Changing their position in the UI
 * Companies/Groups: Organize people in groups
 
+API libraries
+-------------
+
+* [Logan](https://rubygems.org/gems/logan) - Ruby gem
 
 Help us make it better
 ----------------------


### PR DESCRIPTION
Wrote a ruby gem to use Basecamp API in one of our scripts and have published it to RubyGems.org.

Thinking it may be of use to others and figure that the best way to get the word out about these kind of libraries would be to have a section on your README.
