### PR TITLE
Include full-size avatar URLs

### DIFF
--- a/sections/attachments.md
+++ b/sections/attachments.md
@@ -56,7 +56,8 @@ or Comments) with a `200 OK` response.
   "creator": {
     "id": 73,
     "name": "Nick Quaranto",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "attachable": {
     "id": 70219655,
@@ -95,7 +96,8 @@ query, then `&page=3` and so on.
     "creator": {
       "id": 73,
       "name": "Nick Quaranto",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "attachable": {
       "id": 70219655,
@@ -114,7 +116,8 @@ query, then `&page=3` and so on.
     "creator": {
       "id": 73,
       "name": "Nick Quaranto",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "attachable": {
       "id": 12092382,
@@ -141,7 +144,8 @@ Linked attachments like [Google Docs](https://basecamp.com/help/guides/projects/
   "creator": {
     "id": 73,
     "name": "Nick Quaranto",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "attachable": {
     "id": 12092383,

--- a/sections/calendar_events.md
+++ b/sections/calendar_events.md
@@ -30,7 +30,8 @@ Get calendar events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "url": "https://basecamp.com/999999999/api/v1/projects/605816632-bcx/calendar_events/883432030-something-coming-up.json"
   },
@@ -46,7 +47,8 @@ Get calendar events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "url": "https://basecamp.com/999999999/api/v1/projects/605816632-bcx/calendar_events/883432031-more-stuff-for-later.json"
   }
@@ -73,6 +75,7 @@ Get calendar event
     "id": 149087659,
     "name": "Jason Fried",
     "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "url": "https://basecamp.com/999999999/api/v1/projects/605816632-bcx/calendar_events/883432030-something-coming-up.json",
   "comments": [
@@ -86,6 +89,7 @@ Get calendar event
         "id": 149087659,
         "name": "Jason Fried",
         "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ],

--- a/sections/calendars.md
+++ b/sections/calendars.md
@@ -38,7 +38,8 @@ Get calendar
   "creator": {
     "id": 149087659,
     "name": "Jason Fried",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "accesses": {
     "count": 3,

--- a/sections/comments.md
+++ b/sections/comments.md
@@ -28,14 +28,16 @@ Comments are included on the [topics](https://github.com/basecamp/bcx-api/blob/m
             "creator":{
                "id": 73,
                "name": "Nick Quaranto",
-               "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+               "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+               "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
             }
          }
       ],
       "creator": {
         "id": 149087659,
         "name": "Jason Fried",
-        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ]
@@ -66,7 +68,8 @@ This will return `201 Created`, with a representation of the comment just create
   "creator": {
     "id": 149087659,
     "name": "Jason Fried",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "topic_url": "https://basecamp.com/9999999/api/v1/messages/888888.json"
 }

--- a/sections/documents.md
+++ b/sections/documents.md
@@ -51,7 +51,8 @@ Get document
       "creator": {
         "id": 149087659,
         "name": "Jason Fried",
-        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ],

--- a/sections/events.md
+++ b/sections/events.md
@@ -22,7 +22,8 @@ Get global events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "bucket": {
       "id": 605816632,
@@ -40,7 +41,8 @@ Get global events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "bucket": {
       "id": 605816632,
@@ -58,7 +60,8 @@ Get global events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "bucket": {
       "id": 605816632,
@@ -91,7 +94,8 @@ Get project events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "summary": "re-assigned a to-do to Funky ones: Design it",
     "url": "https://basecamp.com/999999999/api/v1/projects/605816632-bcx/todos/223304243-design-it.json"
@@ -103,7 +107,8 @@ Get project events
     "creator": {
       "id": 149087659,
       "name": "Jason Fried",
-      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
     },
     "summary": "added a to-do: t",
     "url": "https://basecamp.com/999999999/api/v1/projects/605816632-bcx/todos/1046098402-t.json"

--- a/sections/messages.md
+++ b/sections/messages.md
@@ -25,7 +25,8 @@ Get message
   "creator": {
     "id": 149087659,
     "name": "Jason Fried",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "comments": [
     {
@@ -36,7 +37,8 @@ Get message
       "creator": {
         "id": 149087659,
         "name": "Jason Fried",
-        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ],

--- a/sections/people.md
+++ b/sections/people.md
@@ -18,6 +18,7 @@ Get people
     "email_address": "jason@basecamp.com",
     "admin": true,
     "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3",
     "created_at": "2012-03-22T16:56:48-05:00",
     "updated_at": "2012-03-22T16:56:48-05:00",
     "url": "https://basecamp.com/999999999/api/v1/people/149087659-jason-fried.json"
@@ -29,6 +30,7 @@ Get people
     "email_address": "jeremy@basecamp.com",
     "admin": true,
     "avatar_url": "https://asset0.37img.com/global/e68cafa694e8f22203eb36f13dccfefa9ac0acb2/avatar.96.gif",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3",
     "created_at": "2012-03-22T16:56:48-05:00",
     "updated_at": "2012-03-22T16:56:48-05:00",
     "url": "https://basecamp.com/999999999/api/v1/people/1071630348-jeremy-kemper.json"
@@ -50,6 +52,7 @@ Get person
   "email_address": "jason@basecamp.com",
   "admin": true,
   "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+  "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3",
   "created_at": "2012-03-22T16:56:51-05:00",
   "updated_at": "2012-03-23T13:55:43-05:00",
   "events": {

--- a/sections/projects.md
+++ b/sections/projects.md
@@ -52,7 +52,8 @@ Get project
   "creator": {
     "id": 149087659,
     "name": "Jason Fried",
-    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
   },
   "accesses": {
     "count": 5,

--- a/sections/todolists.md
+++ b/sections/todolists.md
@@ -24,7 +24,8 @@ Get todolists
     "creator": {
       "id": 127326141,
       "name": "David Heinemeier Hansson",
-      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
     },
   },
   {
@@ -40,7 +41,8 @@ Get todolists
     "creator": {
       "id": 127326141,
       "name": "David Heinemeier Hansson",
-      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
     },
   }
 ]
@@ -66,7 +68,8 @@ Get todolists with assigned todos
     "creator": {
       "id": 127326141,
       "name": "David Heinemeier Hansson",
-      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
     },
     "assigned_todos": [
       {
@@ -94,7 +97,8 @@ Get todolists with assigned todos
     "creator": {
       "id": 127326141,
       "name": "David Heinemeier Hansson",
-      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+      "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+      "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
     },
     "assigned_todos": [
       {
@@ -132,7 +136,8 @@ Get todolist
   "creator": {
     "id": 127326141,
     "name": "David Heinemeier Hansson",
-    "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
   },
   "todos": {
     "remaining": [
@@ -191,7 +196,8 @@ Get todolist
       "creator": {
         "id": 127326141,
         "name": "David Heinemeier Hansson",
-        "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
       }
     }
   ],

--- a/sections/todos.md
+++ b/sections/todos.md
@@ -26,7 +26,8 @@ Get todo
   "creator": {
     "id": 127326141,
     "name": "David Heinemeier Hansson",
-    "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+    "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+    "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
   },
   "assignee": {
     "id": 149087659,
@@ -42,7 +43,8 @@ Get todo
       "creator": {
         "id": 127326141,
         "name": "David Heinemeier Hansson",
-        "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/9d2148cb8ed8e2e8ecbc625dd1cbe7691896c7d9/original.gif?r=3"
       }
     }
   ],

--- a/sections/uploads.md
+++ b/sections/uploads.md
@@ -61,7 +61,8 @@ Each attachment blob includes the `url` parameter, which you can make a
       "creator": {
         "id": 73,
         "name": "Nick Quaranto",
-        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ],
@@ -75,7 +76,8 @@ Each attachment blob includes the `url` parameter, which you can make a
       "creator": {
         "id": 73,
         "name": "Nick Quaranto",
-        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3"
+        "avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/avatar.96.gif?r=3",
+        "fullsize_avatar_url": "https://asset0.37img.com/global/4113d0a133a32931be8934e70b2ea21efeff72c1/original.gif?r=3"
       }
     }
   ],


### PR DESCRIPTION
Provide `fullsize_avatar_url` in addition to the small `avatar_url` thumbnail.

The fullsize URL links to the original, full-size image file. Note: this may be large!
