### PR TITLE
Add remaining todos endpoint docs

### DIFF
--- a/sections/todos.md
+++ b/sections/todos.md
@@ -6,8 +6,9 @@ Get todos
 
 To get an index of all todos on a list, see [todolists](https://github.com/basecamp/bcx-api/blob/master/sections/todolists.md).
 
-* `GET /projects/1/todos.json` shows a list of all todos for this project.
+* `GET /projects/1/todos.json` shows a list of all todos for this project; completed and remaining.
 * `GET /projects/1/todos/completed.json` shows a list of all completed todos for this project.
+* `GET /projects/1/todos/remaining.json` shows a list of all remaining/active todos for this project.
 
 ```json
 [


### PR DESCRIPTION
Adds an endpoint to todos to get all remaining (active, incomplete) todos.

`GET /projects/1/todos/remaining.json` to get all remaining todos in a project.
