### PR TITLE
Document loop-in functionality

### DIFF
--- a/sections/comments.md
+++ b/sections/comments.md
@@ -60,6 +60,16 @@ Create comment
 }
 ```
 
+To "loop-in" outside email addresses for users without an account, include a new_subscriber_emails array with the parameters.
+
+```json
+{
+  "subject": "Hello everyone",
+  "content": "This is going to be a GREAT Saturday!",
+  "new_subscriber_emails": ["example@example.com"]
+}
+```
+
 This will return `201 Created`, with a representation of the comment just created in the response body if the creation was a success. The topic can be accessed via the `topic_url` parameter. For example:
 
 ```json

--- a/sections/messages.md
+++ b/sections/messages.md
@@ -71,6 +71,16 @@ Create message
 }
 ```
 
+To "loop-in" outside email addresses for users without an account, include a new_subscriber_emails array with the parameters.
+
+```json
+{
+  "subject": "Hello everyone",
+  "content": "This is going to be a GREAT Saturday!",
+  "new_subscriber_emails": ["example@example.com"]
+}
+```
+
 This will return `201 Created`, with the location of the new project in the `Location` header along with the current JSON representation of the message  if the creation was a success. See the [Get message](https://github.com/basecamp/bcx-api/blob/master/sections/messages.md#get-message) endpoint for more info.
 
 ### Attaching files


### PR DESCRIPTION
The functionality already exists but was not documented.

Simply pass `new_subscriber_emails` array with your POST request.
